### PR TITLE
Add missing trade in the North-South underground

### DIFF
--- a/locations/encountertab.json
+++ b/locations/encountertab.json
@@ -2611,6 +2611,26 @@
                 ]
             },
             {
+                "name": "Underground Tunnel North-South",
+                "access_rules": [
+					"opt_er_on",
+                    "@Kanto/Vermilion City"
+                ],
+                "sections": [
+                    {
+                        "name": "Trade",
+                        "access_rules": []
+                    }
+                ],
+                "map_locations": [
+                    {
+                        "map": "encounters",
+                        "x": 400,
+                        "y": 144
+                    }
+                ]
+            },
+            {
                 "name": "Fishing Is Fun",
                 "access_rules": [
                     ""

--- a/locations/encountertab.json
+++ b/locations/encountertab.json
@@ -2613,8 +2613,7 @@
             {
                 "name": "Underground Tunnel North-South",
                 "access_rules": [
-					"opt_er_on",
-                    "@Kanto/Vermilion City"
+                    "@Kanto/Underground Tunnel North-Southy"
                 ],
                 "sections": [
                     {
@@ -2992,3 +2991,4 @@
         ]
     }
 ]
+


### PR DESCRIPTION
In vanilla, this is someone giving a Nidoran male for a Nidoran female.

I'm also not too sure about the access rule. I assume that they are the same as in the locations tab.